### PR TITLE
adding task listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Apply the plugin in the main `build.gradle(.kts)` configuration file:
 Using the plugins DSL:
 ``` groovy
 plugins {
-  id("io.github.cdsap.gradleprocess") version "0.1.2"
+  id("io.github.cdsap.gradleprocess") version "0.1.3"
 }
 ```
 
@@ -20,7 +20,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath("io.github.cdsap:infogradleprocess:0.1.2")
+    classpath("io.github.cdsap:infogradleprocess:0.1.3")
   }
 }
 
@@ -31,7 +31,7 @@ apply(plugin = "io.github.cdsap.gradleprocess")
 Using the plugins DSL:
 ``` groovy
 plugins {
-  id "io.github.cdsap.gradleprocess" version "0.1.2"
+  id "io.github.cdsap.gradleprocess" version "0.1.3"
 }
 
 ```
@@ -43,7 +43,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath "io.github.cdsap:infogradleprocess:0.1.2"
+    classpath "io.github.cdsap:infogradleprocess:0.1.3"
   }
 }
 
@@ -56,9 +56,9 @@ Build Scan:
 
 ![](images/buildscan.png)
 
-The field `Usage` represents the value obtained at the end of the build using `jstat` on the JVM process. 
+The field `Usage` represents the value obtained at the end of the build using `jstat` on the JVM process.
 
-> [!NOTE]  
+> [!NOTE]
 Develocity 2024.2 provides new resource usage endpoints with detailed information about the different build and child processes during the execution:
 https://docs.gradle.com/develocity/api-manual/ref/2024.2.html#tag/Builds/operation/GetGradleResourceUsage
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.cdsap"
-version = "0.1.2"
+version = "0.1.3"
 
 java {
     toolchain {

--- a/src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessBuildService.kt
+++ b/src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessBuildService.kt
@@ -6,9 +6,12 @@ import io.github.cdsap.jdk.tools.parser.model.TypeProcess
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
+import org.gradle.tooling.events.FinishEvent
+import org.gradle.tooling.events.OperationCompletionListener
 
 abstract class InfoGradleProcessBuildService :
-    BuildService<InfoGradleProcessBuildService.Params>, AutoCloseable {
+    BuildService<InfoGradleProcessBuildService.Params>, AutoCloseable,
+    OperationCompletionListener {
     interface Params : BuildServiceParameters {
         var jInfoProvider: Provider<String>
         var jStatProvider: Provider<String>
@@ -23,5 +26,8 @@ abstract class InfoGradleProcessBuildService :
         if (processes.isNotEmpty()) {
             ConsoleOutput(processes).print()
         }
+    }
+
+    override fun onFinish(event: FinishEvent?) {
     }
 }

--- a/src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessPlugin.kt
+++ b/src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessPlugin.kt
@@ -12,8 +12,11 @@ import io.github.cdsap.valuesourceprocess.jStat
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
+import org.gradle.build.event.BuildEventsListenerRegistry
+import org.gradle.kotlin.dsl.support.serviceOf
 
 class InfoGradleProcessPlugin : Plugin<Project> {
+
     private val nameProcess = "GradleDaemon"
     override fun apply(target: Project) {
         target.gradle.rootProject {
@@ -34,12 +37,13 @@ class InfoGradleProcessPlugin : Plugin<Project> {
 
 
     private fun consoleReporting(project: Project) {
-        project.gradle.sharedServices.registerIfAbsent(
+        val service = project.gradle.sharedServices.registerIfAbsent(
             "gradleProcessService", InfoGradleProcessBuildService::class.java
         ) {
             parameters.jInfoProvider = project.jInfo(nameProcess)
             parameters.jStatProvider = project.jStat(nameProcess)
-        }.get()
+        }
+        project.serviceOf<BuildEventsListenerRegistry>().onTaskCompletion(service)
     }
 
     private fun buildScanEnterpriseReporting(

--- a/src/test/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessPluginTest.kt
+++ b/src/test/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessPluginTest.kt
@@ -10,7 +10,7 @@ import org.junit.rules.TemporaryFolder
 
 class InfoGradleProcessPluginTest {
 
-    private val gradleVersions = listOf("7.6.2", "8.1.1", "8.6", "8.7")
+    private val gradleVersions = listOf("8.1.1", "8.6", "8.7","8.12.1")
 
     @Rule
     @JvmField
@@ -34,19 +34,21 @@ class InfoGradleProcessPluginTest {
         gradleVersions.forEach {
             val firstBuild = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments("compileKotlin", "--configuration-cache")
+                .withArguments("clean", "compileKotlin", "--no-build-cache", "--configuration-cache")
                 .withPluginClasspath()
                 .withGradleVersion(it)
                 .build()
             val secondBuild = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments("compileKotlin", "--configuration-cache")
+                .withArguments("clean", "compileKotlin", "--no-build-cache", "--configuration-cache")
                 .withPluginClasspath()
                 .withGradleVersion(it)
                 .build()
 
             assertTrue(firstBuild.output.contains("Configuration cache entry stored"))
+            assertTrue(firstBuild.output.contains("Gradle processes"))
             assertTrue(secondBuild.output.contains("Configuration cache entry reused."))
+            assertTrue(secondBuild.output.contains("Gradle processes"))
         }
     }
 


### PR DESCRIPTION
When not using Develocity and hitting the configuration cache, the entry was not displayed. 
This PR adds the `OperationCompletionListener` that forces the service to wait until the last task executed