### PR TITLE
fix: refactor process collection to isolate gradle process parsing

### DIFF
--- a/src/main/kotlin/io/github/cdsap/gradleprocess/DevelocityWrapperConfiguration.kt
+++ b/src/main/kotlin/io/github/cdsap/gradleprocess/DevelocityWrapperConfiguration.kt
@@ -2,8 +2,6 @@ package io.github.cdsap.gradleprocess
 
 import com.gradle.develocity.agent.gradle.DevelocityConfiguration
 import io.github.cdsap.gradleprocess.output.DevelocityValues
-import io.github.cdsap.jdk.tools.parser.ConsolidateProcesses
-import io.github.cdsap.jdk.tools.parser.model.Process
 import io.github.cdsap.jdk.tools.parser.model.TypeProcess
 import io.github.cdsap.valuesourceprocess.jInfo
 import io.github.cdsap.valuesourceprocess.jStat
@@ -26,17 +24,9 @@ class DevelocityWrapperConfiguration {
         val (jStat, jInfo) = providerPair(project)
 
         buildScanExtension.buildScan.buildFinished {
-            val processes = processes(jStat, jInfo)
+            val processes = GradleProcessCollector().collect(jStat, jInfo, TypeProcess.Kotlin)
             DevelocityValues(buildScanExtension, processes).addProcessesInfoToBuildScan()
         }
-    }
-
-    private fun processes(
-        jStat: Provider<String>,
-        jInfo: Provider<String>
-    ): List<Process> {
-        val processes = ConsolidateProcesses().consolidate(jStat.get(), jInfo.get(), TypeProcess.Kotlin)
-        return processes
     }
 
     private fun providerPair(project: Project): Pair<Provider<String>, Provider<String>> {

--- a/src/main/kotlin/io/github/cdsap/gradleprocess/GradleProcessCollector.kt
+++ b/src/main/kotlin/io/github/cdsap/gradleprocess/GradleProcessCollector.kt
@@ -1,0 +1,16 @@
+package io.github.cdsap.gradleprocess
+
+import io.github.cdsap.jdk.tools.parser.ConsolidateProcesses
+import io.github.cdsap.jdk.tools.parser.model.Process
+import io.github.cdsap.jdk.tools.parser.model.TypeProcess
+import org.gradle.api.provider.Provider
+
+internal class GradleProcessCollector {
+    fun collect(
+        jStat: Provider<String>,
+        jInfo: Provider<String>,
+        typeProcess: TypeProcess
+    ): List<Process> {
+        return ConsolidateProcesses().consolidate(jStat.get(), jInfo.get(), typeProcess)
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessBuildService.kt
+++ b/src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessBuildService.kt
@@ -1,7 +1,6 @@
 package io.github.cdsap.gradleprocess
 
 import io.github.cdsap.gradleprocess.output.ConsoleOutput
-import io.github.cdsap.jdk.tools.parser.ConsolidateProcesses
 import io.github.cdsap.jdk.tools.parser.model.TypeProcess
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.BuildService
@@ -18,11 +17,11 @@ abstract class InfoGradleProcessBuildService :
     }
 
     override fun close() {
-        val processes =
-            ConsolidateProcesses().consolidate(
-                parameters.jStatProvider.get(), parameters.jInfoProvider.get(),
-                TypeProcess.Gradle
-            )
+        val processes = GradleProcessCollector().collect(
+            parameters.jStatProvider,
+            parameters.jInfoProvider,
+            TypeProcess.Gradle
+        )
         if (processes.isNotEmpty()) {
             ConsoleOutput(processes).print()
         }

--- a/src/test/kotlin/io/github/cdsap/gradleprocess/GradleProcessCollectorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/gradleprocess/GradleProcessCollectorTest.kt
@@ -1,0 +1,69 @@
+package io.github.cdsap.gradleprocess
+
+import io.github.cdsap.jdk.tools.parser.model.TypeProcess
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GradleProcessCollectorTest {
+
+    @Test
+    fun collectConsolidatesProvidersWithRequestedTypeProcess() {
+        val project = ProjectBuilder.builder().build()
+        val jStat = project.provider {
+            """
+            Timestamp         S0C         S1C         S0U         S1U          EC          EU          OC          OU          MC          MU        CCSC       CCSU     YGC     YGCT     FGC    FGCT     CGC    CGCT       GCT
+                    1117.8          0.0      30720.0          0.0      30720.0    1135616.0     755712.0     865280.0     546816.0     195184.0    189433.3      22208.0    20357.8     22    0.682     0    0.000      12    0.070     0.752
+            28743
+            """.trimIndent()
+        }
+        val jInfo = project.provider {
+            """
+            -XX:+UseParallelGC -XX:MaxHeapSize=536870912
+            28743
+            """.trimIndent()
+        }
+
+        val processes = GradleProcessCollector().collect(jStat, jInfo, TypeProcess.Gradle)
+
+        assertEquals(1, processes.size)
+        assertEquals("28743", processes[0].pid)
+        assertEquals(TypeProcess.Gradle, processes[0].typeProcess)
+        assertEquals("-XX:+UseParallelGC", processes[0].typeGc)
+    }
+
+    @Test
+    fun collectPreservesKotlinTypeProcessForDevelocityPath() {
+        val project = ProjectBuilder.builder().build()
+        val jStat = project.provider {
+            """
+            Timestamp         S0C         S1C         S0U         S1U          EC          EU          OC          OU          MC          MU        CCSC       CCSU     YGC     YGCT     FGC    FGCT     CGC    CGCT       GCT
+                    1117.8          0.0      30720.0          0.0      30720.0    1135616.0     755712.0     865280.0     546816.0     195184.0    189433.3      22208.0    20357.8     22    0.682     0    0.000      12    0.070     0.752
+            28743
+            """.trimIndent()
+        }
+        val jInfo = project.provider {
+            """
+            -XX:+UseParallelGC -XX:MaxHeapSize=536870912
+            28743
+            """.trimIndent()
+        }
+
+        val processes = GradleProcessCollector().collect(jStat, jInfo, TypeProcess.Kotlin)
+
+        assertEquals(1, processes.size)
+        assertEquals(TypeProcess.Kotlin, processes[0].typeProcess)
+    }
+
+    @Test
+    fun collectReturnsEmptyListWhenProvidersHaveNoMatchingProcesses() {
+        val project = ProjectBuilder.builder().build()
+        val jStat = project.provider { "xxxx" }
+        val jInfo = project.provider { "yyyy" }
+
+        val processes = GradleProcessCollector().collect(jStat, jInfo, TypeProcess.Gradle)
+
+        assertTrue(processes.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary

### Problem

Process collection is duplicated inside infrastructure entry points: `src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessBuildService.kt` constructs `ConsolidateProcesses` and chooses `TypeProcess.Gradle`, while `src/main/kotlin/io/github/cdsap/gradleprocess/DevelocityWrapperConfiguration.kt` constructs `ConsolidateProcesses`, reads the same `jStat`/`jInfo` providers, and chooses `TypeProcess.Kotlin`. The output adapters then receive already-parsed process lists, but the collection/parsing boundary is embedded in Gradle service and Develocity wiring code.

### Why this matters

The core behavior of turning `jstat`/`jinfo` provider output into process data is harder to test or reason about independently, and the two reporting paths can drift because each owns its own consolidation call and process-type decision.

### Proposed change

Introduce a small internal collector class, for example `GradleProcessCollector`, that accepts the `Provider<String>` pair and `TypeProcess`, calls `ConsolidateProcesses().consolidate(...)`, and returns `List<Process>`. Update the build-service and Develocity wrapper to delegate to it without changing when providers are created or when values are read.

### Notes

Clean architecture lens: keep Gradle lifecycle and Develocity integration as infrastructure adapters, and move the small domain operation of collecting/parsing Gradle process data into a single core-facing component.

Fixes #48

## Changes

- `src/main/kotlin/io/github/cdsap/gradleprocess/DevelocityWrapperConfiguration.kt`
- `src/main/kotlin/io/github/cdsap/gradleprocess/GradleProcessCollector.kt`
- `src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessBuildService.kt`
- `src/test/kotlin/io/github/cdsap/gradleprocess/GradleProcessCollectorTest.kt`

## Verification

- `./gradlew test`
