### PR TITLE
fix: add https://github.com/cdsap/build-process-watcher in the gha gradl

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,10 @@ jobs:
 
             - name: Setup Gradle
               uses: gradle/actions/setup-gradle@v5
+            - uses: cdsap/build-process-watcher@v0.6.2
+              with:
+                remote_monitoring: 'true'
+                export_to_bigquery: 'true'
             - name: Execute Gradle build
               run:  ./gradlew test -PexcludeTests=*.InfoGradleProcessPluginTest
               env:
@@ -43,6 +47,10 @@ jobs:
 
             - name: Setup Gradle
               uses: gradle/actions/setup-gradle@v5
+            - uses: cdsap/build-process-watcher@v0.6.2
+              with:
+                remote_monitoring: 'true'
+                export_to_bigquery: 'true'
             - name: Execute Gradle build
               run:  |
                 ./gradlew test --tests io.github.cdsap.gradleprocess.InfoGradleProcessPluginTest --info --stacktrace

--- a/src/test/kotlin/io/github/cdsap/gradleprocess/BuildWorkflowProcessWatcherTest.kt
+++ b/src/test/kotlin/io/github/cdsap/gradleprocess/BuildWorkflowProcessWatcherTest.kt
@@ -1,0 +1,25 @@
+package io.github.cdsap.gradleprocess
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class BuildWorkflowProcessWatcherTest {
+
+    @Test
+    fun gradleBuildJobsUseBuildProcessWatcher() {
+        val workflow = File(".github/workflows/build.yaml").readText()
+        val watcherUses = Regex("""uses:\s*cdsap/build-process-watcher@v[\d.]+""")
+            .findAll(workflow)
+            .toList()
+
+        assertEquals(
+            "Expected build-process-watcher in prBranch and integrationJavaTests",
+            2,
+            watcherUses.size
+        )
+        assertTrue(workflow.contains("remote_monitoring: 'true'"))
+        assertTrue(workflow.contains("export_to_bigquery: 'true'"))
+    }
+}


### PR DESCRIPTION
## Summary

Add https://github.com/cdsap/build-process-watcher in the GHA gradle builds

Fixes #49

## Changes

- `.github/workflows/build.yaml`
- `src/test/kotlin/io/github/cdsap/gradleprocess/BuildWorkflowProcessWatcherTest.kt`

## Verification

- `./gradlew test`
