### PR TITLE
fix: refactor process collection to shared core helper

### DIFF
--- a/src/main/kotlin/io/github/cdsap/gradleprocess/DevelocityWrapperConfiguration.kt
+++ b/src/main/kotlin/io/github/cdsap/gradleprocess/DevelocityWrapperConfiguration.kt
@@ -24,7 +24,7 @@ class DevelocityWrapperConfiguration {
         val (jStat, jInfo) = providerPair(project)
 
         buildScanExtension.buildScan.buildFinished {
-            val processes = GradleProcessCollector().collect(jStat, jInfo, TypeProcess.Kotlin)
+            val processes = GradleProcessCollector().collect(jStat.get(), jInfo.get(), TypeProcess.Kotlin)
             DevelocityValues(buildScanExtension, processes).addProcessesInfoToBuildScan()
         }
     }

--- a/src/main/kotlin/io/github/cdsap/gradleprocess/GradleProcessCollector.kt
+++ b/src/main/kotlin/io/github/cdsap/gradleprocess/GradleProcessCollector.kt
@@ -3,14 +3,13 @@ package io.github.cdsap.gradleprocess
 import io.github.cdsap.jdk.tools.parser.ConsolidateProcesses
 import io.github.cdsap.jdk.tools.parser.model.Process
 import io.github.cdsap.jdk.tools.parser.model.TypeProcess
-import org.gradle.api.provider.Provider
 
 internal class GradleProcessCollector {
     fun collect(
-        jStat: Provider<String>,
-        jInfo: Provider<String>,
+        jStat: String,
+        jInfo: String,
         typeProcess: TypeProcess
     ): List<Process> {
-        return ConsolidateProcesses().consolidate(jStat.get(), jInfo.get(), typeProcess)
+        return ConsolidateProcesses().consolidate(jStat, jInfo, typeProcess)
     }
 }

--- a/src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessBuildService.kt
+++ b/src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessBuildService.kt
@@ -18,8 +18,8 @@ abstract class InfoGradleProcessBuildService :
 
     override fun close() {
         val processes = GradleProcessCollector().collect(
-            parameters.jStatProvider,
-            parameters.jInfoProvider,
+            parameters.jStatProvider.get(),
+            parameters.jInfoProvider.get(),
             TypeProcess.Gradle
         )
         if (processes.isNotEmpty()) {

--- a/src/test/kotlin/io/github/cdsap/gradleprocess/GradleProcessCollectorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/gradleprocess/GradleProcessCollectorTest.kt
@@ -1,7 +1,6 @@
 package io.github.cdsap.gradleprocess
 
 import io.github.cdsap.jdk.tools.parser.model.TypeProcess
-import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -9,21 +8,16 @@ import org.junit.Test
 class GradleProcessCollectorTest {
 
     @Test
-    fun collectConsolidatesProvidersWithRequestedTypeProcess() {
-        val project = ProjectBuilder.builder().build()
-        val jStat = project.provider {
-            """
+    fun collectConsolidatesStringsWithRequestedTypeProcess() {
+        val jStat = """
             Timestamp         S0C         S1C         S0U         S1U          EC          EU          OC          OU          MC          MU        CCSC       CCSU     YGC     YGCT     FGC    FGCT     CGC    CGCT       GCT
                     1117.8          0.0      30720.0          0.0      30720.0    1135616.0     755712.0     865280.0     546816.0     195184.0    189433.3      22208.0    20357.8     22    0.682     0    0.000      12    0.070     0.752
             28743
             """.trimIndent()
-        }
-        val jInfo = project.provider {
-            """
+        val jInfo = """
             -XX:+UseParallelGC -XX:MaxHeapSize=536870912
             28743
             """.trimIndent()
-        }
 
         val processes = GradleProcessCollector().collect(jStat, jInfo, TypeProcess.Gradle)
 
@@ -35,20 +29,15 @@ class GradleProcessCollectorTest {
 
     @Test
     fun collectPreservesKotlinTypeProcessForDevelocityPath() {
-        val project = ProjectBuilder.builder().build()
-        val jStat = project.provider {
-            """
+        val jStat = """
             Timestamp         S0C         S1C         S0U         S1U          EC          EU          OC          OU          MC          MU        CCSC       CCSU     YGC     YGCT     FGC    FGCT     CGC    CGCT       GCT
                     1117.8          0.0      30720.0          0.0      30720.0    1135616.0     755712.0     865280.0     546816.0     195184.0    189433.3      22208.0    20357.8     22    0.682     0    0.000      12    0.070     0.752
             28743
             """.trimIndent()
-        }
-        val jInfo = project.provider {
-            """
+        val jInfo = """
             -XX:+UseParallelGC -XX:MaxHeapSize=536870912
             28743
             """.trimIndent()
-        }
 
         val processes = GradleProcessCollector().collect(jStat, jInfo, TypeProcess.Kotlin)
 
@@ -57,12 +46,8 @@ class GradleProcessCollectorTest {
     }
 
     @Test
-    fun collectReturnsEmptyListWhenProvidersHaveNoMatchingProcesses() {
-        val project = ProjectBuilder.builder().build()
-        val jStat = project.provider { "xxxx" }
-        val jInfo = project.provider { "yyyy" }
-
-        val processes = GradleProcessCollector().collect(jStat, jInfo, TypeProcess.Gradle)
+    fun collectReturnsEmptyListWhenStringsHaveNoMatchingProcesses() {
+        val processes = GradleProcessCollector().collect("xxxx", "yyyy", TypeProcess.Gradle)
 
         assertTrue(processes.isEmpty())
     }


### PR DESCRIPTION
## Summary

### Problem

Process collection is duplicated across `src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessBuildService.kt` and `src/main/kotlin/io/github/cdsap/gradleprocess/DevelocityWrapperConfiguration.kt`: both call `ConsolidateProcesses().consolidate(...)` directly with provider values and a `TypeProcess`. This makes the console and Develocity reporting paths each know infrastructure details about jstat/jinfo parsing.

### Why this matters

Duplicated collection logic increases the chance that console output and Build Scan values drift over time. It also makes the core behavior harder to test without exercising Gradle build-service or Develocity wiring.

### Proposed change

Introduce a small internal helper, for example `GradleProcessCollector`, that accepts the jstat string, jinfo string, and existing `TypeProcess`, then delegates to `ConsolidateProcesses`. Update `InfoGradleProcessBuildService` and `DevelocityWrapperConfiguration` to use it while preserving their current `TypeProcess.Gradle` and `TypeProcess.Kotlin` behavior.

### Notes

This is a small clean-architecture improvement: process collection becomes core behavior, while Gradle build-service lifecycle and Develocity Build Scan integration remain infrastructure/adapters.

Fixes #53

## Changes

- `src/main/kotlin/io/github/cdsap/gradleprocess/DevelocityWrapperConfiguration.kt`
- `src/main/kotlin/io/github/cdsap/gradleprocess/GradleProcessCollector.kt`
- `src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessBuildService.kt`
- `src/test/kotlin/io/github/cdsap/gradleprocess/GradleProcessCollectorTest.kt`

## Verification

- `./gradlew test`
