### PR TITLE
fix: refactor process collection to a shared collector

### DIFF
--- a/src/main/kotlin/io/github/cdsap/gradleprocess/DevelocityWrapperConfiguration.kt
+++ b/src/main/kotlin/io/github/cdsap/gradleprocess/DevelocityWrapperConfiguration.kt
@@ -24,7 +24,7 @@ class DevelocityWrapperConfiguration {
         val (jStat, jInfo) = providerPair(project)
 
         buildScanExtension.buildScan.buildFinished {
-            val processes = GradleProcessCollector().collect(jStat.get(), jInfo.get(), TypeProcess.Kotlin)
+            val processes = ProcessInfoCollector().collect(jStat, jInfo, TypeProcess.Kotlin)
             DevelocityValues(buildScanExtension, processes).addProcessesInfoToBuildScan()
         }
     }

--- a/src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessBuildService.kt
+++ b/src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessBuildService.kt
@@ -17,9 +17,9 @@ abstract class InfoGradleProcessBuildService :
     }
 
     override fun close() {
-        val processes = GradleProcessCollector().collect(
-            parameters.jStatProvider.get(),
-            parameters.jInfoProvider.get(),
+        val processes = ProcessInfoCollector().collect(
+            parameters.jStatProvider,
+            parameters.jInfoProvider,
             TypeProcess.Gradle
         )
         if (processes.isNotEmpty()) {

--- a/src/main/kotlin/io/github/cdsap/gradleprocess/ProcessInfoCollector.kt
+++ b/src/main/kotlin/io/github/cdsap/gradleprocess/ProcessInfoCollector.kt
@@ -3,13 +3,14 @@ package io.github.cdsap.gradleprocess
 import io.github.cdsap.jdk.tools.parser.ConsolidateProcesses
 import io.github.cdsap.jdk.tools.parser.model.Process
 import io.github.cdsap.jdk.tools.parser.model.TypeProcess
+import org.gradle.api.provider.Provider
 
-internal class GradleProcessCollector {
+internal class ProcessInfoCollector {
     fun collect(
-        jStat: String,
-        jInfo: String,
+        jStat: Provider<String>,
+        jInfo: Provider<String>,
         typeProcess: TypeProcess
     ): List<Process> {
-        return ConsolidateProcesses().consolidate(jStat, jInfo, typeProcess)
+        return ConsolidateProcesses().consolidate(jStat.get(), jInfo.get(), typeProcess)
     }
 }

--- a/src/test/kotlin/io/github/cdsap/gradleprocess/ProcessInfoCollectorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/gradleprocess/ProcessInfoCollectorTest.kt
@@ -1,25 +1,31 @@
 package io.github.cdsap.gradleprocess
 
 import io.github.cdsap.jdk.tools.parser.model.TypeProcess
+import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class GradleProcessCollectorTest {
+class ProcessInfoCollectorTest {
 
     @Test
-    fun collectConsolidatesStringsWithRequestedTypeProcess() {
-        val jStat = """
+    fun collectConsolidatesProvidersWithRequestedTypeProcess() {
+        val project = ProjectBuilder.builder().build()
+        val jStat = project.provider {
+            """
             Timestamp         S0C         S1C         S0U         S1U          EC          EU          OC          OU          MC          MU        CCSC       CCSU     YGC     YGCT     FGC    FGCT     CGC    CGCT       GCT
                     1117.8          0.0      30720.0          0.0      30720.0    1135616.0     755712.0     865280.0     546816.0     195184.0    189433.3      22208.0    20357.8     22    0.682     0    0.000      12    0.070     0.752
             28743
             """.trimIndent()
-        val jInfo = """
+        }
+        val jInfo = project.provider {
+            """
             -XX:+UseParallelGC -XX:MaxHeapSize=536870912
             28743
             """.trimIndent()
+        }
 
-        val processes = GradleProcessCollector().collect(jStat, jInfo, TypeProcess.Gradle)
+        val processes = ProcessInfoCollector().collect(jStat, jInfo, TypeProcess.Gradle)
 
         assertEquals(1, processes.size)
         assertEquals("28743", processes[0].pid)
@@ -29,25 +35,34 @@ class GradleProcessCollectorTest {
 
     @Test
     fun collectPreservesKotlinTypeProcessForDevelocityPath() {
-        val jStat = """
+        val project = ProjectBuilder.builder().build()
+        val jStat = project.provider {
+            """
             Timestamp         S0C         S1C         S0U         S1U          EC          EU          OC          OU          MC          MU        CCSC       CCSU     YGC     YGCT     FGC    FGCT     CGC    CGCT       GCT
                     1117.8          0.0      30720.0          0.0      30720.0    1135616.0     755712.0     865280.0     546816.0     195184.0    189433.3      22208.0    20357.8     22    0.682     0    0.000      12    0.070     0.752
             28743
             """.trimIndent()
-        val jInfo = """
+        }
+        val jInfo = project.provider {
+            """
             -XX:+UseParallelGC -XX:MaxHeapSize=536870912
             28743
             """.trimIndent()
+        }
 
-        val processes = GradleProcessCollector().collect(jStat, jInfo, TypeProcess.Kotlin)
+        val processes = ProcessInfoCollector().collect(jStat, jInfo, TypeProcess.Kotlin)
 
         assertEquals(1, processes.size)
         assertEquals(TypeProcess.Kotlin, processes[0].typeProcess)
     }
 
     @Test
-    fun collectReturnsEmptyListWhenStringsHaveNoMatchingProcesses() {
-        val processes = GradleProcessCollector().collect("xxxx", "yyyy", TypeProcess.Gradle)
+    fun collectReturnsEmptyListWhenProvidersHaveNoMatchingProcesses() {
+        val project = ProjectBuilder.builder().build()
+        val jStat = project.provider { "xxxx" }
+        val jInfo = project.provider { "yyyy" }
+
+        val processes = ProcessInfoCollector().collect(jStat, jInfo, TypeProcess.Gradle)
 
         assertTrue(processes.isEmpty())
     }


### PR DESCRIPTION
## Summary

### Problem

Process collection is embedded directly in Gradle integration classes: `src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessBuildService.kt` constructs `ConsolidateProcesses` in `close()`, while `src/main/kotlin/io/github/cdsap/gradleprocess/DevelocityWrapperConfiguration.kt` has a separate `processes(...)` helper that repeats the provider `.get()` and consolidation flow. That couples reporting adapters to the jdk-tools-parser infrastructure detail.

### Why this matters

The console and Develocity paths are two delivery adapters for the same core behavior. Keeping consolidation logic inside both adapters makes future changes to process parsing, filtering, or error handling easier to apply inconsistently and harder to test without exercising Gradle lifecycle wiring.

### Proposed change

Introduce a small internal `ProcessInfoCollector` in the main `gradleprocess` package that accepts the `jStat` and `jInfo` providers plus the existing `TypeProcess`, calls `ConsolidateProcesses().consolidate(...)`, and returns the process list. Update `InfoGradleProcessBuildService` and `DevelocityWrapperConfiguration` to delegate to it while preserving the current `TypeProcess.Gradle` and `TypeProcess.Kotlin` choices exactly.

### Notes

Clean architecture lens: this keeps Gradle lifecycle/build scan adapters focused on registration and output, while the core process collection behavior sits behind a small local boundary. It is intentionally narrow and behavior-preserving rather than a larger domain model rewrite.

Fixes #56

## Changes

- `src/main/kotlin/io/github/cdsap/gradleprocess/DevelocityWrapperConfiguration.kt`
- `src/main/kotlin/io/github/cdsap/gradleprocess/GradleProcessCollector.kt`
- `src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessBuildService.kt`
- `src/main/kotlin/io/github/cdsap/gradleprocess/ProcessInfoCollector.kt`
- `src/test/kotlin/io/github/cdsap/gradleprocess/GradleProcessCollectorTest.kt`
- `src/test/kotlin/io/github/cdsap/gradleprocess/ProcessInfoCollectorTest.kt`

## Verification

- `./gradlew test`
