### PR TITLE
fix: refactor process provider creation to clarify collection boundary

### DIFF
--- a/src/main/kotlin/io/github/cdsap/gradleprocess/DevelocityWrapperConfiguration.kt
+++ b/src/main/kotlin/io/github/cdsap/gradleprocess/DevelocityWrapperConfiguration.kt
@@ -3,10 +3,7 @@ package io.github.cdsap.gradleprocess
 import com.gradle.develocity.agent.gradle.DevelocityConfiguration
 import io.github.cdsap.gradleprocess.output.DevelocityValues
 import io.github.cdsap.jdk.tools.parser.model.TypeProcess
-import io.github.cdsap.valuesourceprocess.jInfo
-import io.github.cdsap.valuesourceprocess.jStat
 import org.gradle.api.Project
-import org.gradle.api.provider.Provider
 
 class DevelocityWrapperConfiguration {
 
@@ -21,17 +18,15 @@ class DevelocityWrapperConfiguration {
         project: Project,
         buildScanExtension: DevelocityConfiguration
     ) {
-        val (jStat, jInfo) = providerPair(project)
+        val processInfoProviders = ProcessInfoProviders.create(project)
 
         buildScanExtension.buildScan.buildFinished {
-            val processes = ProcessInfoCollector().collect(jStat, jInfo, TypeProcess.Kotlin)
+            val processes = ProcessInfoCollector().collect(
+                processInfoProviders.jStat,
+                processInfoProviders.jInfo,
+                TypeProcess.Kotlin
+            )
             DevelocityValues(buildScanExtension, processes).addProcessesInfoToBuildScan()
         }
-    }
-
-    private fun providerPair(project: Project): Pair<Provider<String>, Provider<String>> {
-        val jStat = project.jStat(Constants.GRADLE_PROCESS_NAME)
-        val jInfo = project.jInfo(Constants.GRADLE_PROCESS_NAME)
-        return Pair(jStat, jInfo)
     }
 }

--- a/src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessPlugin.kt
+++ b/src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessPlugin.kt
@@ -1,8 +1,5 @@
 package io.github.cdsap.gradleprocess
 
-import io.github.cdsap.gradleprocess.Constants.Companion.GRADLE_PROCESS_NAME
-import io.github.cdsap.valuesourceprocess.jInfo
-import io.github.cdsap.valuesourceprocess.jStat
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.build.event.BuildEventsListenerRegistry
@@ -30,11 +27,12 @@ class InfoGradleProcessPlugin : Plugin<Project> {
 
 
     private fun consoleReporting(project: Project) {
+        val processInfoProviders = ProcessInfoProviders.create(project)
         val service = project.gradle.sharedServices.registerIfAbsent(
             "gradleProcessService", InfoGradleProcessBuildService::class.java
         ) {
-            parameters.jInfoProvider = project.jInfo(GRADLE_PROCESS_NAME)
-            parameters.jStatProvider = project.jStat(GRADLE_PROCESS_NAME)
+            parameters.jInfoProvider = processInfoProviders.jInfo
+            parameters.jStatProvider = processInfoProviders.jStat
         }
         project.serviceOf<BuildEventsListenerRegistry>().onTaskCompletion(service)
     }

--- a/src/main/kotlin/io/github/cdsap/gradleprocess/ProcessInfoProviders.kt
+++ b/src/main/kotlin/io/github/cdsap/gradleprocess/ProcessInfoProviders.kt
@@ -1,0 +1,20 @@
+package io.github.cdsap.gradleprocess
+
+import io.github.cdsap.valuesourceprocess.jInfo
+import io.github.cdsap.valuesourceprocess.jStat
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+
+internal data class ProcessInfoProviders(
+    val jStat: Provider<String>,
+    val jInfo: Provider<String>
+) {
+    companion object {
+        fun create(project: Project): ProcessInfoProviders {
+            return ProcessInfoProviders(
+                jStat = project.jStat(Constants.GRADLE_PROCESS_NAME),
+                jInfo = project.jInfo(Constants.GRADLE_PROCESS_NAME)
+            )
+        }
+    }
+}

--- a/src/test/kotlin/io/github/cdsap/gradleprocess/ProcessInfoCollectorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/gradleprocess/ProcessInfoCollectorTest.kt
@@ -3,6 +3,7 @@ package io.github.cdsap.gradleprocess
 import io.github.cdsap.jdk.tools.parser.model.TypeProcess
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -54,6 +55,17 @@ class ProcessInfoCollectorTest {
 
         assertEquals(1, processes.size)
         assertEquals(TypeProcess.Kotlin, processes[0].typeProcess)
+    }
+
+    @Test
+    fun processInfoProvidersCreatesGradleJdkToolProviders() {
+        val project = ProjectBuilder.builder().build()
+
+        val providers = ProcessInfoProviders.create(project)
+
+        // Assert construction only; do not evaluate ValueSources (avoids jstat/jinfo).
+        assertNotNull(providers.jStat)
+        assertNotNull(providers.jInfo)
     }
 
     @Test


### PR DESCRIPTION
## Summary

### Problem

`DevelocityWrapperConfiguration.kt` owns a private `providerPair(project)` helper that creates `jStat` and `jInfo` providers, while `InfoGradleProcessPlugin.kt` creates the same providers inline in `consoleReporting`. This duplicates infrastructure wiring across the Develocity and console paths instead of keeping provider construction near the shared process-collection boundary.

### Why this matters

The plugin has two reporting adapters but one process information source. Duplicated provider wiring makes future changes to the process lookup command, process name, or provider setup easier to apply inconsistently between Build Scan and console reporting.

### Proposed change

Introduce a small internal helper, for example `ProcessInfoProviders`, that creates the `jStat` and `jInfo` providers for `GRADLE_PROCESS_NAME`. Use it from both `DevelocityWrapperConfiguration` and `InfoGradleProcessPlugin.consoleReporting`, leaving `ProcessInfoCollector` as the shared collector and preserving all behavior.

### Notes

From a clean architecture lens, this keeps Gradle provider/value-source infrastructure separate from the collection use case and keeps the two reporting adapters focused on presentation and lifecycle integration.

Fixes #61

## Changes

- `src/main/kotlin/io/github/cdsap/gradleprocess/DevelocityWrapperConfiguration.kt`
- `src/main/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessPlugin.kt`
- `src/main/kotlin/io/github/cdsap/gradleprocess/ProcessInfoProviders.kt`
- `src/test/kotlin/io/github/cdsap/gradleprocess/ProcessInfoCollectorTest.kt`

## Verification

- `./gradlew test`
