### PR TITLE
fix: declare plugin portal configuration-cache compatibility (and prove

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,10 @@
+import org.gradle.plugin.compatibility.compatibility
+
 plugins {
     `java-gradle-plugin`
     `maven-publish`
     `kotlin-dsl`
-    id("com.gradle.plugin-publish") version "1.0.0-rc-1"
+    id("com.gradle.plugin-publish") version "2.1.1"
 }
 
 group = "io.github.cdsap"
@@ -30,19 +32,22 @@ tasks.withType<Test>().configureEach {
     }
 }
 gradlePlugin {
+    website.set("https://github.com/cdsap/InfoGradleProcess")
+    vcsUrl.set("https://github.com/cdsap/InfoGradleProcess")
     plugins {
         create("InfoGradleProcessPlugin") {
             id = "io.github.cdsap.gradleprocess"
             displayName = "Info Gradle Processes"
             description = "Retrieve information of the Gradle processes after the build execution"
             implementationClass = "io.github.cdsap.gradleprocess.InfoGradleProcessPlugin"
+            tags.set(listOf("process"))
+            compatibility {
+                features {
+                    configurationCache = true
+                }
+            }
         }
     }
-}
-pluginBundle {
-    website = "https://github.com/cdsap/InfoGradleProcess"
-    vcsUrl = "https://github.com/cdsap/InfoGradleProcess"
-    tags = listOf("process")
 }
 
 publishing {

--- a/src/test/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessNoDVTest.kt
+++ b/src/test/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessNoDVTest.kt
@@ -39,18 +39,32 @@ class InfoGradleProcessNoDVTest {
         listOf("8.14.2", "9.1.0").forEach {
             val firstBuild = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments("compileKotlin", "--configuration-cache")
+                .withArguments(
+                    "compileKotlin",
+                    "--configuration-cache",
+                    "--configuration-cache-problems=fail"
+                )
                 .withPluginClasspath()
                 .withGradleVersion(it)
                 .build()
             val secondBuild = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments("compileKotlin", "--configuration-cache")
+                .withArguments(
+                    "compileKotlin",
+                    "--configuration-cache",
+                    "--configuration-cache-problems=fail"
+                )
                 .withPluginClasspath()
                 .withGradleVersion(it)
                 .build()
-            TestCase.assertTrue(firstBuild.output.contains("Configuration cache entry stored"))
-            TestCase.assertTrue(secondBuild.output.contains("Configuration cache entry reused."))
+            TestCase.assertTrue(
+                "Gradle $it first run should store configuration cache",
+                firstBuild.output.contains("Configuration cache entry stored")
+            )
+            TestCase.assertTrue(
+                "Gradle $it second run should be a configuration-cache HIT",
+                secondBuild.output.contains("Configuration cache entry reused.")
+            )
         }
     }
 

--- a/src/test/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessPluginTest.kt
+++ b/src/test/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessPluginTest.kt
@@ -3,7 +3,6 @@ package io.github.cdsap.gradleprocess
 import junit.framework.TestCase.assertTrue
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
-import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -36,21 +35,35 @@ class InfoGradleProcessPluginTest {
         gradleVersions.forEach {
             val firstBuild = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments("clean", "compileKotlin", "--no-build-cache", "--configuration-cache")
+                .withArguments(
+                    "compileKotlin",
+                    "--no-build-cache",
+                    "--configuration-cache",
+                    "--configuration-cache-problems=fail"
+                )
                 .withPluginClasspath()
                 .withGradleVersion(it)
                 .build()
             val secondBuild = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments("clean", "compileKotlin", "--no-build-cache", "--configuration-cache")
+                .withArguments(
+                    "compileKotlin",
+                    "--no-build-cache",
+                    "--configuration-cache",
+                    "--configuration-cache-problems=fail"
+                )
                 .withPluginClasspath()
                 .withGradleVersion(it)
                 .build()
 
-            assertTrue(firstBuild.output.contains("Configuration cache entry stored"))
-            assertTrue(firstBuild.output.contains("Gradle processes"))
-            assertTrue(secondBuild.output.contains("Configuration cache entry reused."))
-            assertTrue(secondBuild.output.contains("Gradle processes"))
+            assertTrue(
+                "Gradle $it first run should store configuration cache",
+                firstBuild.output.contains("Configuration cache entry stored")
+            )
+            assertTrue(
+                "Gradle $it second run should be a configuration-cache HIT",
+                secondBuild.output.contains("Configuration cache entry reused.")
+            )
         }
     }
 


### PR DESCRIPTION
## Summary

### Notes

Related Gradle docs: https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:plugins

Fixes #63

## Changes

- `build.gradle.kts`
- `src/test/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessNoDVTest.kt`
- `src/test/kotlin/io/github/cdsap/gradleprocess/InfoGradleProcessPluginTest.kt`

## Verification

- `./gradlew test`
